### PR TITLE
Add SQLite-based post history via ActiveRecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ gem 'uri', '~> 0.13'
 gem 'yaml', '~> 0.1'
 
 gem "activerecord", "~> 7.2"
-gem "sqlite3", "~> 2.5"
+gem "sqlite3", "~> 2.7"

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,6 @@ gem 'json', '~> 2.5'
 gem 'net-http', '~> 0.2'
 gem 'uri', '~> 0.13'
 gem 'yaml', '~> 0.1'
+
+gem "activerecord", "~> 7.2"
+gem "sqlite3", "~> 2.5"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Tootify stores configs and data in the `config` folder:
 
 * `bluesky.yml` – created when you log in, stores Bluesky user ID/password and access tokens
 * `mastodon.yml` – created when you log in, stores Mastodon user ID/password and access tokens
-* `history.csv` – stores a mapping between Bluesky and Mastodon post IDs; used for reply references in threads
+* `history.sqlite3` – stores a mapping between Bluesky and Mastodon post IDs; used for reply references in threads
 * `tootify.yml` - optional additional configuration
 
 The config in `tootify.yml` currently supports one option:

--- a/app/database.rb
+++ b/app/database.rb
@@ -1,0 +1,19 @@
+require 'active_record'
+require 'fileutils'
+
+module Database
+  DB_FILE = File.expand_path(File.join(__dir__, '..', 'config', 'history.sqlite3'))
+  MIGRATIONS_PATH = File.expand_path(File.join(__dir__, '..', 'db', 'migrate'))
+
+  def self.connect
+    FileUtils.mkdir_p(File.dirname(DB_FILE))
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: DB_FILE)
+    run_migrations
+  end
+
+  def self.run_migrations
+    ActiveRecord::Migration.verbose = false
+    migration_context = ActiveRecord::MigrationContext.new(MIGRATIONS_PATH, ActiveRecord::SchemaMigration)
+    migration_context.migrate
+  end
+end

--- a/app/database.rb
+++ b/app/database.rb
@@ -13,7 +13,7 @@ module Database
 
   def self.run_migrations
     ActiveRecord::Migration.verbose = false
-    migration_context = ActiveRecord::MigrationContext.new(MIGRATIONS_PATH, ActiveRecord::SchemaMigration)
+    migration_context = ActiveRecord::MigrationContext.new(MIGRATIONS_PATH)
     migration_context.migrate
   end
 end

--- a/app/post.rb
+++ b/app/post.rb
@@ -1,0 +1,4 @@
+require 'active_record'
+
+class Post < ActiveRecord::Base
+end

--- a/app/post_history.rb
+++ b/app/post_history.rb
@@ -1,23 +1,16 @@
-class PostHistory
-  HISTORY_FILE = File.expand_path(File.join(__dir__, '..', 'config', 'history.csv'))
+require_relative 'database'
+require_relative 'post'
 
+class PostHistory
   def initialize
-    if File.exist?(HISTORY_FILE)
-      @id_map = File.read(HISTORY_FILE).lines.map { |l| l.strip.split(',') }.then { |pairs| Hash[pairs] }
-    else
-      @id_map = {}
-    end
+    Database.connect
   end
 
   def [](bluesky_rkey)
-    @id_map[bluesky_rkey]
+    Post.find_by(bluesky_rkey: bluesky_rkey)&.mastodon_id
   end
 
   def add(bluesky_rkey, mastodon_id)
-    @id_map[bluesky_rkey] = mastodon_id
-
-    File.open(HISTORY_FILE, 'a') do |f|
-      f.puts("#{bluesky_rkey},#{mastodon_id}")
-    end
+    Post.create!(bluesky_rkey: bluesky_rkey, mastodon_id: mastodon_id)
   end
 end

--- a/db/migrate/001_create_posts.rb
+++ b/db/migrate/001_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.string :bluesky_rkey, null: false
+      t.string :mastodon_id, null: false
+    end
+
+    add_index :posts, :bluesky_rkey, unique: true
+  end
+end


### PR DESCRIPTION
## Summary
- switch post history storage from CSV to SQLite
- introduce `Database` helper for initializing ActiveRecord
- create `Post` model and migration for `posts` table
- document new sqlite file in README
- add activerecord & sqlite3 dependencies
- address feedback: update gem versions, simplify migration setup, remove redundant table name, use `create!`

## Testing
- `ruby -c app/post_history.rb`
- `ruby -c app/database.rb`
- `ruby -c db/migrate/001_create_posts.rb`
- `ruby -c app/post.rb`
- `ruby -c app/tootify.rb`
- `ruby -c tootify`

Codex couldn't run `bundle install` due to environment limitations.

------
https://chatgpt.com/codex/tasks/task_e_68485e798a6883319e69d147c69eb728